### PR TITLE
Added enet_host_compress_with_range_coder binding

### DIFF
--- a/host.go
+++ b/host.go
@@ -54,8 +54,10 @@ func (host *enetHost) Connect(addr Address, channelCount int, data uint32) (Peer
 func (host *enetHost) CompressWithRangeCoder() error {
 	status := C.enet_host_compress_with_range_coder(host.cHost)
 
-	if status != 0 {
+	if status == -1 {
 		return errors.New("couldn't set the packet compressor to default range coder because context is nil")
+	} else if status != 0 {
+		return errors.New("couldn't set the packet compressor to default range coder for unknown reason")
 	}
 
 	return nil

--- a/host.go
+++ b/host.go
@@ -49,6 +49,16 @@ func (host *enetHost) Connect(addr Address, channelCount int, data uint32) (Peer
 	}, nil
 }
 
+func (host *enetHost) CompressWithRangeCoder() error {
+	status := C.enet_host_compress_with_range_coder(host.cHost)
+
+	if status != 0 {
+		return errors.New("couldn't set the packet compressor to default range coder because context is nil")
+	}
+
+	return nil
+}
+
 // NewHost creats a host for communicating to peers
 func NewHost(addr Address, peerCount, channelLimit uint64, incomingBandwidth, outgoingBandwidth uint32) (Host, error) {
 	var cAddr *C.struct__ENetAddress

--- a/host.go
+++ b/host.go
@@ -12,6 +12,8 @@ type Host interface {
 	Service(timeout uint32) Event
 
 	Connect(addr Address, channelCount int, data uint32) (Peer, error)
+
+	CompressWithRangeCoder() error
 }
 
 type enetHost struct {


### PR DESCRIPTION
I was working on writing a new server whose existing clients demanded that compression be enabled so I needed to add this binding.

The related enet code can be found here. 
https://github.com/lsalzman/enet/blob/master/compress.c#L637