### PR TITLE
Added GetConnectedId to Peer

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -12,6 +12,7 @@ import (
 // Peer is a peer which data packets may be sent or received from
 type Peer interface {
 	GetAddress() Address
+	GetConnectId() uint
 
 	Disconnect(data uint32)
 	DisconnectNow(data uint32)
@@ -49,6 +50,10 @@ func (peer enetPeer) GetAddress() Address {
 	return &enetAddress{
 		cAddr: peer.cPeer.address,
 	}
+}
+
+func (peer enetPeer) GetConnectId() uint {
+	return uint(peer.cPeer.connectID)
 }
 
 func (peer enetPeer) Disconnect(data uint32) {


### PR DESCRIPTION
I added GetConnectedId in Peer because I needed it. If I need more, I can fill in the gaps and more pr.