### PR TITLE
Use case sensitive windows library names.

### DIFF
--- a/enetc.go
+++ b/enetc.go
@@ -2,7 +2,7 @@ package enet
 
 // #cgo !windows pkg-config: libenet
 // #cgo windows CFLAGS: -Ienet/include/
-// #cgo windows LDFLAGS: -Lenet/ -lenet -lWs2_32 -lWinmm
+// #cgo windows LDFLAGS: -Lenet/ -lenet -lws2_32 -lwinmm
 // #include <enet/enet.h>
 import "C"
 import "fmt"


### PR DESCRIPTION
Library names are case sensitive when compiling from WSL

When `enetc.go` has `// #cgo windows LDFLAGS: -Lenet/ -lenet -lWs2_32 -lWinmm` then building fails with the following message:

```
# client
/home/insood/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/pkg/tool/linux_amd64/link: running x86_64-w64-mingw32-gcc failed: exit status 1
/usr/bin/x86_64-w64-mingw32-gcc -m64 -mconsole -Wl,--tsaware -Wl,--nxcompat -Wl,--major-os-version=6 -Wl,--minor-os-version=1 -Wl,--major-subsystem-version=6 -Wl,--minor-subsystem-version=1 -Wl,--dynamicbase -Wl,--high-entropy-va -o $WORK/b001/exe/a.out.exe -Wl,--no-insert-timestamp /tmp/go-link-2783558612/go.o /tmp/go-link-2783558612/000000.o /tmp/go-link-2783558612/000001.o /tmp/go-link-2783558612/000002.o /tmp/go-link-2783558612/000003.o /tmp/go-link-2783558612/000004.o /tmp/go-link-2783558612/000005.o /tmp/go-link-2783558612/000006.o /tmp/go-link-2783558612/000007.o /tmp/go-link-2783558612/000008.o /tmp/go-link-2783558612/000009.o /tmp/go-link-2783558612/000010.o /tmp/go-link-2783558612/000011.o /tmp/go-link-2783558612/000012.o /tmp/go-link-2783558612/000013.o /tmp/go-link-2783558612/000014.o -O2 -g -L/home/insood/go/pkg/mod/github.com/codecat/go-enet@v0.0.0-20250111122620-4dd2fcc21203/enet -lenet -lWs2_32 -lWinmm -O2 -g -Wl,-T,/tmp/go-link-2783558612/fix_debug_gdb_scripts.ld -Wl,--start-group -lmingwex -lmingw32 -Wl,--end-group -lkernel32
/usr/bin/x86_64-w64-mingw32-ld: cannot find -lWs2_32: No such file or directory
/usr/bin/x86_64-w64-mingw32-ld: cannot find -lWinmm: No such file or directory
collect2: error: ld returned 1 exit status
```

Changing `enetc.go` to `// #cgo windows LDFLAGS: -Lenet/ -lenet -lws2_32 -lwinmm` fixes this issue. I don't think this should lead to issues on windows machines since they are case-insensitive.

A temporary solution has been to edit my `go.mod` file to point to a version where this is fixed: `replace github.com/codecat/go-enet => github.com/insood/go-enet v0.0.0-20250226233553-4838c0e53d04`
